### PR TITLE
Add media query for tooltip enable/disable

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -166,6 +166,11 @@ nav ul a {
     margin: 0 !important;
 }
 
+#media-query {
+    display: none;
+    width: 2px;
+}
+
 /* Media queries */
 @media only screen and (max-width: 500px) {
     h5 {
@@ -183,5 +188,9 @@ nav ul a {
 
     .title {
         font-size: 4rem;
+    }
+
+    #media-query {
+        width: 1px;
     }
 }

--- a/public/assets/js/slider.js
+++ b/public/assets/js/slider.js
@@ -102,3 +102,11 @@ $('#resource-category-submit').on('click', function() {
 
     });
 });
+
+// This function ensure that tooltips can also be removed by window resizing, in case the window is
+// large enough when the tooltips are added but then resized to be smaller.
+$(window).resize(function(){
+    if ($('#media-query').width() === 1 ) {
+        $('.tooltipped').tooltip('disable').tooltip('remove');
+    }
+});

--- a/public/assets/js/slider.js
+++ b/public/assets/js/slider.js
@@ -51,10 +51,14 @@ $('#feeling-submit').on('click', function() {
         ['1', '2', '3', '4'].forEach(function(item) {
             var percentage = Math.round(data[item] * 100);
 
-            if (percentage) {
-                $('#label-' + item[0]).attr('data-tooltip', percentage + '% of people feeling ' + feelingText + ' chose this.').tooltip();
+            if ($('#media-query').width() === 2) {
+                if (percentage) {
+                    $('#label-' + item[0]).attr('data-tooltip', percentage + '% of people feeling ' + feelingText + ' chose this.').tooltip('enable');
+                } else {
+                    $('#label-' + item[0]).attr('data-tooltip', '0% of people feeling ' + feelingText + ' chose this.').tooltip('enable');
+                }
             } else {
-                $('#label-' + item[0]).attr('data-tooltip', '0% of people feeling ' + feelingText + ' chose this.').tooltip();
+                $('.tooltipped').tooltip('disable').tooltip('remove');
             }
         });
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -49,6 +49,7 @@
             </div>
         </div>
     </footer>
+    <div id="media-query"></div>
 
     <!--  Scripts-->
     <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>


### PR DESCRIPTION
I added a small hidden div that changes size at breakpoints. Before adding tooltips on slide 5, jQuery checks the size of that div. If its size indicates we're below 500px wide, the tooltips don't get added. I just need to add one thing.